### PR TITLE
[BUG/security] 페이지 새로고침 시 리프레시 토큰 에러 발생

### DIFF
--- a/src/components/AuthInitializer.tsx
+++ b/src/components/AuthInitializer.tsx
@@ -2,22 +2,31 @@
 
 import { useEffect } from 'react';
 import { authApi } from '@/api/auth';
+import { useAuthStore } from '@/store/useAuthStore';
 
 export default function AuthInitializer() {
+    const loadTokenFromStorage = useAuthStore((state) => state.loadTokenFromStorage);
+
     useEffect(() => {
         const initAuth = async () => {
+            // 1단계: localStorage에서 기존 토큰 복원 시도
+            const existingToken = loadTokenFromStorage();
+
+            if (existingToken) {
+                // 토큰이 있으면 그냥 사용 - refresh 불필요!
+                return;
+            }
+
+            // 2단계: 토큰 없을 때만 refresh 시도
             try {
-                // 앱 진입 시 리프레시 토큰(쿠키)을 이용해 새 액세스 토큰 발급 시도
-                // authApi 내부에서 싱글톤 + useAuthStore 업데이트 처리됨
                 await authApi.refreshAccessToken();
             } catch {
-                // 토큰이 없거나 만료된 경우 - 로그인 안 된 상태 유지
-                // console.log("세션 정보가 없거나 만료되었습니다.");
+                // 세션 없음 - 로그인 필요
             }
         };
 
         initAuth();
-    }, []);
+    }, [loadTokenFromStorage]);
 
     return null;
 }


### PR DESCRIPTION
# 🐛 버그 수정 PR인 경우

## #️⃣ 연관된 이슈
close: #26 

## 📝 수정 요약
새로고침 시 복불복으로 인증 에러 발생
localStorage에서 토큰 복원 먼저 시도

- 🚨 문제점
  - `AUTH_REFRESH_TOKEN_INVALID` (유효하지 않은 리프레시 토큰)
  - `NullPointerException: MemberPrincipal.publicId() is null`
- 🔍 원인 분석
  - 액세스 토큰 미복원
    - 1. 액세스 토큰이 localStorage에 저장됨
    - 2. 하지만 페이지 로드 시 복원하는 코드가 없음
    - 3. 매번 불필요하게 `refreshAccessToken()` 호출
    - 4. 동시 호출 시 Race Condition 발생 → 에러
- 💡 해결 방법
  - `AuthInitializer.tsx`: localStorage에서 토큰 복원 먼저 시도

## 🛠️ PR 유형
- [x] 버그 수정

## ✅ PR Checklist
- [x] 커밋 메시지 컨벤션을 지켰습니다.
- [x] 변경 사항에 대한 테스트를 완료했습니다.

## 🤔 Review 예상 시간
3분